### PR TITLE
feat: 通用化 agent-rules 与本地同步脚本

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,30 +1,6 @@
-# Guidelines
+# 由 CI 同步生成
 
-## Language Protocol
-- **Processing**: Think in English for technical precision, respond exclusively in Simplified Chinese (简体中文).
-- **Consistency**: All user interactions must be in Chinese - no exceptions.
+本文件内容来自仓库根目录的 `AGENT_RULES.md`，请勿直接编辑。
 
-## Output Protocol
-- IMPORTANT: Always minimize output tokens - answer concisely without unnecessary preamble or elaboration.
+要修改规则，请更新 `AGENT_RULES.md`。
 
-## Verbosity Override
-- Allow for more detailed responses when the user explicitly asks. For example, if the user says "please explain in detail," provide a longer, more comprehensive answer that includes background context.
-
-## Code of Conduct
-- **Confirmation First**: Always analyze and confirm user intentions before making any code changes or file modifications.
-- **Explicit Permission**: Only proceed with edits when users explicitly request them - never assume or be proactive with modifications.
-- **Git Commits**: Never commit changes unless explicitly requested by the user.
-- **Tool Preference**: Avoid overusing .sh scripts; prefer built-in tools and direct commands.
-- **Modern First Approach**: Don't overcomplicate designs for backward compatibility with legacy frameworks or older versions. Unless users explicitly request compatibility considerations, always architect and code according to the latest requirements and best practices.
-
-## Documentation Standards
-- **No Time Estimations**: When creating documentation, never estimate task durations - these are ineffective information.
-
-## Git instructions
-- Create a git commit with detailed log using Simplified Chinese (简体中文).
-- **When adding new lines to commit message, use multiple `-m`s**. Example: `git commit -m "feat: 实现自动化部署集成" -m "- description of the feature 1" -m "- description of the feature 2"`.
-
-## PR Description (gh CLI)
-- Do not use escaped “\n” in --body; they render literally.
-- Prefer --body-file to pass Markdown content.
-- Suggested structure: Summary; Impact; Notes; References/Links.

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,33 +1,6 @@
-# Guidelines
+# 由 CI 同步生成
 
-## Language Protocol
-- **Processing**: Think in English for technical precision, respond exclusively in Simplified Chinese (简体中文).
-- **Consistency**: All user interactions must be in Chinese - no exceptions.
+本文件内容来自仓库根目录的 `AGENT_RULES.md`，请勿直接编辑。
 
-## Output Protocol
-- IMPORTANT: Always minimize output tokens - answer concisely without unnecessary preamble or elaboration.
+要修改规则，请更新 `AGENT_RULES.md`。
 
-## Verbosity Override
-- Allow for more detailed responses when the user explicitly asks. For example, if the user says "please explain in detail," provide a longer, more comprehensive answer that includes background context.
-
-## Code of Conduct
-- **Confirmation First**: Always analyze and confirm user intentions before making any code changes or file modifications.
-- **Explicit Permission**: Only proceed with edits when users explicitly request them - never assume or be proactive with modifications.
-- **Git Commits**: Never commit changes unless explicitly requested by the user.
-- **Tool Preference**: Avoid overusing .sh scripts; prefer built-in tools and direct commands.
-- **Modern First Approach**: Don't overcomplicate designs for backward compatibility with legacy frameworks or older versions. Unless users explicitly request compatibility considerations, always architect and code according to the latest requirements and best practices.
-
-## Documentation Standards
-- **No Time Estimations**: When creating documentation, never estimate task durations - these are ineffective information.
-
-## Git instructions
-- Create a git commit with detailed log using Simplified Chinese (简体中文).
-- **When adding new lines to commit message, use multiple `-m`s**. Example: `git commit -m "feat: 实现自动化部署集成" -m "- description of the feature 1" -m "- description of the feature 2"`.
-
-## PR Description (gh CLI)
-- Do not use escaped “\n” in --body; they render literally.
-- Prefer --body-file to pass Markdown content.
-- Suggested structure: Summary; Impact; Notes; References/Links.
-
-## Quick start
-- Read the CLAUDE.md documentation (if it exists) for a quick overview of the project.

--- a/.github/workflows/sync-agent-rules.yml
+++ b/.github/workflows/sync-agent-rules.yml
@@ -1,0 +1,39 @@
+name: Sync Agent Rules
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare files
+        run: |
+          mkdir -p .claude .codex
+          cp -f AGENT_RULES.md .claude/CLAUDE.md
+          cp -f AGENT_RULES.md .codex/AGENTS.md
+
+      - name: Commit changes if any
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .claude/CLAUDE.md .codex/AGENTS.md
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -m "chore(sync): 同步 AGENT_RULES.md 到下游 [skip ci]" \
+                     -m "- 更新 .claude/CLAUDE.md 与 .codex/AGENTS.md" \
+                     -m "- 由 GitHub Actions 自动执行，避免循环触发"
+          git push
+

--- a/AGENT_RULES.md
+++ b/AGENT_RULES.md
@@ -1,0 +1,34 @@
+# Guidelines
+
+## Language Protocol
+- **Processing**: Think in English for technical precision, respond exclusively in Simplified Chinese (简体中文).
+- **Consistency**: All user interactions must be in Chinese - no exceptions.
+
+## Output Protocol
+- IMPORTANT: Always minimize output tokens - answer concisely without unnecessary preamble or elaboration.
+
+## Verbosity Override
+- Allow for more detailed responses when the user explicitly asks. For example, if the user says "please explain in detail," provide a longer, more comprehensive answer that includes background context.
+
+## Code of Conduct
+- **Confirmation First**: Always analyze and confirm user intentions before making any code changes or file modifications.
+- **Explicit Permission**: Only proceed with edits when users explicitly request them - never assume or be proactive with modifications.
+- **Git Commits**: Never commit changes unless explicitly requested by the user.
+- **Tool Preference**: Avoid overusing .sh scripts; prefer built-in tools and direct commands.
+- **Modern First Approach**: Don't overcomplicate designs for backward compatibility with legacy frameworks or older versions. Unless users explicitly request compatibility considerations, always architect and code according to the latest requirements and best practices.
+
+## Documentation Standards
+- **No Time Estimations**: When creating documentation, never estimate task durations - these are ineffective information.
+
+## Git instructions
+- Create a git commit with detailed log using Simplified Chinese (简体中文).
+- **When adding new lines to commit message, use multiple `-m`s**. Example: `git commit -m "feat: 实现自动化部署集成" -m "- description of the feature 1" -m "- description of the feature 2"`.
+
+## PR Description (gh CLI)
+- Do not use escaped “\n” in --body; they render literally.
+- Prefer --body-file to pass Markdown content.
+- Suggested structure: Summary; Impact; Notes; References/Links.
+
+## API Design
+- Naming & Language: Use English for paths, parameters, response keys, and code; use Chinese for comments.
+- HTTP Semantics: Use GET/POST/PUT/PATCH/DELETE appropriately; use standard 2xx/4xx/5xx status codes; avoid overusing 200.

--- a/README.md
+++ b/README.md
@@ -1,178 +1,58 @@
-# Claude Code 配置模板仓库
+# agent-rules（多 Agent 统一规则与同步）
 
-一个用于管理和同步 Claude Code 配置文件和自定义命令的模板仓库。
-
-## 项目概述
-
-本项目提供了一套完整的 Claude Code 配置模板，包括全局配置文件和各种实用的 slash 命令。通过一键同步功能，用户可以轻松获取并保持最新的配置模板。
+将多种 AI Agent（Claude、Codex 等）的规则集中到单一真源 `AGENT_RULES.md`，
+通过 CI 自动同步到下游文件，并提供 Bash 脚本在本地覆盖更新 `~/.claude`、`~/.codex`、`~/.gemini`。
 
 ## 目录结构
 
 ```
 .
+├── AGENT_RULES.md                  # 唯一真源（SSOT）
 ├── .claude/
-│   ├── CLAUDE.md                    # Claude 全局配置文件（语言协议、行为准则等）
-│   └── commands/                    # 自定义 slash 命令目录
-│       ├── sync-templates.md        # 🔄 模板同步命令（核心功能）
-│       ├── security-review.md       # 🔐 安全代码审查命令
-│       └── git/                     # Git 相关命令组
-│           ├── commit.md            # Git 提交辅助
-│           └── workflow.md          # Git 工作流指导
-├── .gitignore                       # Git 忽略规则
-└── README.md                        # 项目说明（本文件）
+│   └── CLAUDE.md                   # 由 CI 复制自 AGENT_RULES.md
+├── .codex/
+│   └── AGENTS.md                   # 由 CI 复制自 AGENT_RULES.md
+├── scripts/
+│   └── sync-agent-rules.sh         # 本地同步脚本（macOS/Linux）
+└── .github/workflows/
+    └── sync-agent-rules.yml        # CI：同步 SSOT 到下游
 ```
 
 ## 快速开始
 
-### 1. 获取模板
-
 ```bash
-# 克隆项目（方式一：推荐）
 git clone https://github.com/jeejeeguan/agent-rules.git
 cd agent-rules
 
-# 或直接下载（方式二）
-curl -L https://github.com/jeejeeguan/agent-rules/archive/main.zip -o agent-rules.zip
-unzip agent-rules.zip && cd agent-rules-main
-```
-
-### 2. 同步到本地配置
-
-在项目目录下启动 Claude Code：
-
-```bash
-claude
-```
-
-执行同步命令：
-
-```
-/sync-templates
-```
-
-**就这么简单！** 🎉
-
-### 3. 验证安装
-
-同步完成后，检查本地配置：
-
-```bash
-ls -la ~/.claude/
-ls -R ~/.claude/commands/
-```
-
-### 4. 清理（可选）
-
-模板同步完成后，项目文件夹可以删除：
-
-```bash
-cd .. && rm -rf agent-rules
-```
-
-以后在任何目录下都可以使用 `/sync-templates` 命令更新模板。
-
-## 核心功能：同步命令详解
-
-### `/sync-templates` 命令
-
-这是本项目的核心功能，用于将远程仓库的配置模板同步到本地 `~/.claude/` 目录。
-
-#### 使用方法
-
-```bash
 # 同步默认分支（main）
-/sync-templates
+bash scripts/sync-agent-rules.sh
 
-# 同步指定分支
-/sync-templates dev
+# 或指定分支
+bash scripts/sync-agent-rules.sh exp/breaking-rewrite
 ```
 
-#### 功能特性
+脚本行为：
+- 仅覆盖“仓库中存在的同名文件”；不会删除你本地的多余文件
+- 覆盖前自动备份到 `~/.agent-rules-backup/<agent>/...`，备份文件名追加 `_YYYYMMDD_HHMMSS_backup`
+- 支持的本地目录：`~/.claude`、`~/.codex`、`~/.gemini`（存在才处理）
 
-- ✅ **完整同步**：自动同步 `CLAUDE.md` 和整个 `commands/` 目录（含子目录）
-- ✅ **智能备份**：同步前自动备份现有配置到 `~/.claude/backup/时间戳/`
-- ✅ **分支支持**：可指定同步不同分支的配置
-- ✅ **错误处理**：网络异常或其他错误时提供明确提示
-- ✅ **进度反馈**：实时显示同步进度和结果
+依赖：`curl`、`tar`（macOS 和 Linux 默认可用）。
 
-#### 工作原理
+## CI 自动同步（SSOT）
 
-1. **下载**：从 GitHub 下载整个仓库的 tarball 压缩包
-2. **备份**：将现有的 `~/.claude/` 配置备份到带时间戳的目录
-3. **解压**：解压下载的压缩包到临时目录
-4. **同步**：将 `.claude/` 目录内容复制到 `~/.claude/`
-5. **清理**：删除临时文件，显示同步结果
+- 当 `main` 分支有 push（包含合并 PR）时，CI 将：
+  - 将 `AGENT_RULES.md` 复制到 `.claude/CLAUDE.md` 与 `.codex/AGENTS.md`
+  - 如有变更则自动提交（带 `[skip ci]`，避免循环）
+- 维护规则时，仅编辑根目录的 `AGENT_RULES.md` 即可。
 
-#### 输出示例
+## 自定义（Fork）
 
+Fork 后可通过环境变量覆盖脚本默认仓库：
+
+```bash
+REPO_OWNER="你的用户名" REPO_NAME="agent-rules" bash scripts/sync-agent-rules.sh main
 ```
-📦 同步分支: main
-🔗 源仓库: https://github.com/jeejeeguan/agent-rules/
-⬇️  下载中: https://codeload.github.com/jeejeeguan/agent-rules/tar.gz/refs/heads/main
-💾 备份到: /Users/username/.claude/backup/20241225_143022
-📂 解压中...
-✓ 已更新 CLAUDE.md
-✓ 已更新 commands/ 目录（含子目录）
-
-✅ 同步完成！
-📋 当前文件列表:
-━━━━━━━━━━━━━━━
-/Users/username/.claude/commands:
-git
-security-review.md
-sync-templates.md
-...
-```
-
-## 可用命令
-
-同步完成后，以下 slash 命令将在 Claude Code 中可用：
-
-| 命令 | 描述 | 用途 |
-|------|------|------|
-| `/sync-templates` | 🔄 模板同步 | 从远程仓库更新本地配置 |
-| `/security-review` | 🔐 安全审查 | 对代码进行安全漏洞检查 |
-| `/git/commit` | 📝 提交助手 | 生成规范的 Git 提交信息 |
-| `/git/workflow` | 🌊 工作流 | Git 分支管理和协作指导 |
-
-## 自定义配置
-
-### Fork 本仓库
-
-如果你想自定义配置模板：
-
-1. Fork 本仓库到你的 GitHub 账号
-2. 修改 `.claude/commands/sync-templates.md` 中的仓库地址：
-   ```bash
-   REPO_OWNER="你的用户名"
-   REPO_NAME="agent-rules"
-   ```
-3. 添加或修改 `.claude/` 目录下的配置文件
-4. 提交并推送更改
-
-### 添加新命令
-
-在 `.claude/commands/` 目录下创建新的 `.md` 文件，支持任意深度的子目录结构：
-
-```
-.claude/commands/
-├── 你的命令.md
-├── 分类目录/
-│   ├── 子命令1.md
-│   └── 深层目录/
-│       └── 子命令2.md
-```
-
-
-## 贡献
-
-欢迎提交 [Issue](https://github.com/jeejeeguan/agent-rules/issues) 和 Pull Request！
 
 ## 许可证
 
-本项目采用 MIT 许可证 - 查看 [LICENSE](LICENSE) 文件了解详情。
-
-
----
-
-**开始使用：`git clone` → `claude` → `/sync-templates` 🚀**
+MIT，见 [LICENSE](LICENSE)。

--- a/scripts/sync-agent-rules.sh
+++ b/scripts/sync-agent-rules.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# agent-rules 本地同步脚本（macOS / Linux）
+# 仅覆盖同名文件；不删除本地多余文件。
+# 备份到 ~/.agent-rules-backup/<agent>/...，并在备份文件名追加 _YYYYMMDD_HHMMSS_backup 后缀。
+
+REPO_OWNER=${REPO_OWNER:-"jeejeeguan"}
+REPO_NAME=${REPO_NAME:-"agent-rules"}
+BRANCH=${1:-${BRANCH:-"main"}}
+
+COLOR_BLUE='\033[34m'
+COLOR_GREEN='\033[32m'
+COLOR_YELLOW='\033[33m'
+COLOR_RESET='\033[0m'
+
+timestamp() { date '+%Y%m%d_%H%M%S'; }
+
+echo -e "${COLOR_BLUE}📦 同步分支:${COLOR_RESET} ${BRANCH}"
+echo -e "${COLOR_BLUE}🔗 源仓库:${COLOR_RESET} https://github.com/${REPO_OWNER}/${REPO_NAME}"
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "缺少依赖: $1" >&2; exit 2; }
+}
+
+need_cmd curl
+need_cmd tar
+
+TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t agentrules)
+cleanup() { rm -rf "$TMPDIR" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+TARBALL_URL="https://codeload.github.com/${REPO_OWNER}/${REPO_NAME}/tar.gz/refs/heads/${BRANCH}"
+TARBALL="${TMPDIR}/src.tar.gz"
+
+echo -e "${COLOR_BLUE}⬇️  下载:${COLOR_RESET} ${TARBALL_URL}"
+curl -fsSL "$TARBALL_URL" -o "$TARBALL"
+
+echo -e "${COLOR_BLUE}📂 解压中...${COLOR_RESET}"
+tar -xzf "$TARBALL" -C "$TMPDIR"
+
+# 找到解压后的根目录（形如 repo-<sha>）
+SRC_DIR=$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -type d -name "${REPO_NAME}-*" | head -n1)
+if [ -z "${SRC_DIR}" ]; then
+  echo "未找到解压目录" >&2
+  exit 3
+fi
+
+AGENTS=(claude codex gemini)
+HOME_DIR=${HOME}
+BACKUP_ROOT="${HOME_DIR}/.agent-rules-backup"
+TS=$(timestamp)
+
+changed_total=0
+skipped_total=0
+
+for agent in "${AGENTS[@]}"; do
+  local_dir="${HOME_DIR}/.${agent}"
+  remote_dir="${SRC_DIR}/.${agent}"
+
+  if [ ! -d "$local_dir" ]; then
+    echo -e "${COLOR_YELLOW}⚠️  跳过: ~/${agent} 不存在${COLOR_RESET}"
+    continue
+  fi
+
+  if [ ! -d "$remote_dir" ]; then
+    echo -e "${COLOR_YELLOW}⚠️  跳过: 远端不含 .${agent}/ 目录${COLOR_RESET}"
+    continue
+  fi
+
+  echo -e "${COLOR_BLUE}🔄 同步 .${agent}/ → ~/.${agent}/（仅覆盖同名文件）${COLOR_RESET}"
+
+  while IFS= read -r -d '' f; do
+    rel_path=${f#"${remote_dir}/"}
+    dst_path="${local_dir}/${rel_path}"
+
+    if [ -f "$dst_path" ]; then
+      mkdir -p "${BACKUP_ROOT}/${agent}/$(dirname "$rel_path")"
+      base_name=$(basename "$dst_path")
+      backup_path="${BACKUP_ROOT}/${agent}/$(dirname "$rel_path")/${base_name}_${TS}_backup"
+      cp -p "$dst_path" "$backup_path"
+
+      mkdir -p "$(dirname "$dst_path")"
+      cp -p "$f" "$dst_path"
+      echo -e "${COLOR_GREEN}✓ 覆盖:${COLOR_RESET} ~/.${agent}/${rel_path}  （备份→ ${backup_path})"
+      changed_total=$((changed_total+1))
+    else
+      echo -e "${COLOR_YELLOW}↷ 跳过新文件:${COLOR_RESET} ~/.${agent}/${rel_path}（本地不存在同名文件）"
+      skipped_total=$((skipped_total+1))
+    fi
+  done < <(find "$remote_dir" -type f -print0)
+done
+
+echo
+echo -e "${COLOR_GREEN}✅ 完成${COLOR_RESET} 覆盖: ${changed_total}，跳过: ${skipped_total}"
+echo -e "备份目录: ${BACKUP_ROOT}"
+


### PR DESCRIPTION
## Summary
- 将仓库升级为通用 agent-rules（单一真源 AGENT_RULES.md）
- 本地同步脚本（macOS/Linux），仅覆盖同名文件并自动备份
- CI 在 main 更新时自动将 AGENT_RULES.md 分发到 .claude 与 .codex

## Impact
- 降低多 Agent 规则维护成本（避免重复粘贴）
- 本地设备可一键覆盖已有配置，保留增量文件
- 自动化保障规则一致性（main push/合并后即生效）

## Notes
- 备份路径：~/.agent-rules-backup/<agent>/...；文件名后缀：_YYYYMMDD_HHMMSS_backup
- 同步策略：仅覆盖仓库存在的同名文件；不删除本地多余文件
- 旧的 Claude /sync-templates 可在本 PR 合并后移除

## References/Links
- 脚本：scripts/sync-agent-rules.sh
- 工作流：.github/workflows/sync-agent-rules.yml
