### PR TITLE
docs: README 统一为可执行脚本示例

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # agent-rules（多 Agent 统一规则与同步）
 
 将多种 AI Agent（Claude、Codex 等）的规则集中到单一真源 `AGENT_RULES.md`，
-通过 CI 自动同步到下游文件，并提供 Bash 脚本在本地覆盖更新 `~/.claude`、`~/.codex`、`~/.gemini`。
+通过 CI 自动同步到下游文件，并提供可执行脚本在本地覆盖更新 `~/.claude`、`~/.codex`、`~/.gemini`。
 
 ## 目录结构
 
@@ -25,10 +25,10 @@ git clone https://github.com/jeejeeguan/agent-rules.git
 cd agent-rules
 
 # 同步默认分支（main）
-bash scripts/sync-agent-rules.sh
+./scripts/sync-agent-rules.sh
 
 # 或指定分支
-bash scripts/sync-agent-rules.sh exp/breaking-rewrite
+./scripts/sync-agent-rules.sh exp/breaking-rewrite
 ```
 
 脚本行为：
@@ -50,7 +50,7 @@ bash scripts/sync-agent-rules.sh exp/breaking-rewrite
 Fork 后可通过环境变量覆盖脚本默认仓库：
 
 ```bash
-REPO_OWNER="你的用户名" REPO_NAME="agent-rules" bash scripts/sync-agent-rules.sh main
+REPO_OWNER="你的用户名" REPO_NAME="agent-rules" ./scripts/sync-agent-rules.sh main
 ```
 
 ## 许可证


### PR DESCRIPTION
## Summary
- README 改为“可执行脚本”表述，不区分 bash/zsh
- 用法示例改为 ./scripts/sync-agent-rules.sh [分支]
- 自定义示例改为前缀环境变量 + 可执行脚本

## Impact
- 降低用户对 Shell 的感知与要求

## Notes
- 依赖：macOS/Linux；需 curl、tar
